### PR TITLE
fix: change prop name for button

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -51,7 +51,7 @@ export default tseslint.config({
     ],
     '@typescript-eslint/no-explicit-any': 'error',
     'no-magic-numbers': 'off',
-    '@typescript-eslint/no-magic-numbers': 'error',
+    '@typescript-eslint/no-magic-numbers': ['error', { ignore: [0, 1] }],
     '@typescript-eslint/no-unsafe-argument': 'error',
     'no-use-before-define': 'off',
     '@typescript-eslint/no-use-before-define': 'error',

--- a/src/components/PrimaryButton/PrimaryButton.tsx
+++ b/src/components/PrimaryButton/PrimaryButton.tsx
@@ -3,12 +3,12 @@ import type { ReactElement } from 'react';
 
 export interface ButtonProps {
   title: string;
-  externalLink?: string;
+  link?: string;
   type?: 'button' | 'reset' | 'submit';
   onClick?: (event: React.FormEvent) => void;
 }
 
-export const PrimaryButton = ({ title, externalLink, type = 'button', onClick }: ButtonProps): ReactElement => {
+export const PrimaryButton = ({ title, link, type = 'button', onClick }: ButtonProps): ReactElement => {
   const primaryButtonHandler = (event: React.FormEvent): void => {
     if (onClick) {
       event.preventDefault();
@@ -16,7 +16,7 @@ export const PrimaryButton = ({ title, externalLink, type = 'button', onClick }:
     }
   };
 
-  if (externalLink) {
+  if (link) {
     return (
       <Button
         asChild
@@ -28,7 +28,7 @@ export const PrimaryButton = ({ title, externalLink, type = 'button', onClick }:
         paddingY='4'
         onClick={primaryButtonHandler}
       >
-        <a href={externalLink}>{title}</a>
+        <a href={link}>{title}</a>
       </Button>
     );
   }


### PR DESCRIPTION

## Description of Changes
Для лучшей совместимости с уже написанным кодом поменяно имя поля для компонента PrimaryButton.

## Related Issues
RSS-ECOMM-2_34

## What Has Been Done

- Числа 0 и 1 добавлены в исключения для правила eslint 'no-magic-numbers'
- Переименовано поле PrimaryButton с externalLink на link.

## Points to Pay Attention To

--

## Related Pull Requests

https://github.com/Nadin-Nov/memory-mart/pull/15
